### PR TITLE
Network schema io neil

### DIFF
--- a/scripts/tn_json_readers.py
+++ b/scripts/tn_json_readers.py
@@ -346,12 +346,13 @@ def populateArray(inputArr, lines):
 		itms = getArrayFromMulti(typeItem)
 		for itm in itms:
 			inputArr[pos] = itm
-			pos += 1
 			if pos > 255:
 				print("Err - line item {} pushed past the end of the array from {}".format(itm, lines))
 				# raise IndexError("Error OOB from lineitem")
 
 				return inputArr
+			pos += 1
+
 
 	return inputArr
 

--- a/scripts/tn_json_readers.py
+++ b/scripts/tn_json_readers.py
@@ -321,10 +321,10 @@ def getArrayFromMulti(jItem):
 
 		if jItem.count(':') == 1:
 			start = int(vals[0])
-			end = int(vals[1]) + start + -1
+			end = int(vals[1])+1
 		else:
 			start = int(vals[0])
-			end = int(vals[2]) + start + -1
+			end = int(vals[2])+1
 			increment = int(vals[1])
 
 		rng = np.arange(start, end, increment, dtype=np.int32)
@@ -333,7 +333,7 @@ def getArrayFromMulti(jItem):
 		sp = jItem.split('x')
 		num = int(sp[1])
 		val = int(sp[0])
-		its = [val] * (num - 1)
+		its = [val] * (num)
 		return np.array(its, dtype=np.int32)
 	else:
 		return [int(jItem)]

--- a/scripts/tn_json_readers.py
+++ b/scripts/tn_json_readers.py
@@ -373,7 +373,7 @@ def createNeMoCFGFromJson(filename, modelFN='nemo_model.nfg1'):
 	neuronTemplates = ntmp
 	nc = 0
 
-	cfgFile = ConfigFile(modelFN)
+	cfgFile = ConfigFile(modelFN,nc = len(cores))
 
 	print("Generating CSV...")
 	data = []

--- a/scripts/tn_json_readers.py
+++ b/scripts/tn_json_readers.py
@@ -228,6 +228,16 @@ def createNeuronTemplateFromEntry(line, nSynapses=256, weights=4):
 	return neuron
 
 
+def convertNeuronName(neuronName):
+	"""
+	Converts the neuron type name to an integer. The input is in hex. The actual naming doesn't particularly matter in
+	this case so this function makes any changes consistent
+	:param neuronName: neuron type name of format: hex string
+	:return: integer representing neuron type
+	"""
+	return int(neuronName,16)
+
+
 def getNeuronModels(neuronTypes, nsynapses=256, nweights=4):
 	"""
 	Generates a dictionary of predefined neuron types (per the neuron templates desc. in the TN documentation)
@@ -240,7 +250,7 @@ def getNeuronModels(neuronTypes, nsynapses=256, nweights=4):
 	for name, vals in zip(neuronTypes.keys(), neuronTypes.values()):
 		name = name.replace("N", "")
 		neuronTemplates[name] = createNeuronTemplateFromEntry(vals, nsynapses, nweights)
-		neuronTemplates[name].nnid = int(name)
+		neuronTemplates[name].nnid = convertNeuronName(name)
 	return neuronTemplates
 
 
@@ -292,7 +302,9 @@ def readTN(filename):
 
 	for nk in neuronTypes.keys():
 		n_num = nk.replace('N', '')
-		neuronTypes[nk]['nid'] = int(n_num)
+		n_num = convertNeuronName(n_num)
+
+		neuronTypes[nk]['nid'] = n_num
 
 	crossbarDat = parseCrossbar(crossbarDat, mdl['crossbarSize'])
 	return (mdl, neuronTypes, crossbarDat, coreDat)
@@ -439,8 +451,8 @@ def neuronCSVFut(cores, crossbars, nc, neuronTemplates):
 				if neuron.destCore < 0 or neuron.destLocal < 0:
 					neuron.selfFiring = 1
 				nrs.append(neuron)
-#			else:
-#				neuron = TN(256, 4)
+			#			else:
+			#				neuron = TN(256, 4)
 
 
 		# for i in nrs:
@@ -487,7 +499,7 @@ def readAndSaveSpikeFile(filename, type="json", saveFile="spikes.csv"):
 if __name__ == '__main__':
 	print("Testing read TN Json")
 	print("Example 1 JSON file loading")
-	ex1_model = createNeMoCFGFromJson('./test/ex1.json')
+	ex1_model = createNeMoCFGFromJson('./test/mnist.json','neil_mnist_nemo_model.nfg1')
 	ex1_model.closeFile()
 	print("Example 1 JSON Spike load")
 	readAndSaveSpikeFile('./test/ex1_spikes.sfti', saveFile='nemo_spike.csv')


### PR DESCRIPTION
Bugfixes to the JSON -> NFG1 filetype creation script:

1. Neuron name had assumed that it was of type TN followed by several ints 0-9. It was actually followed by hex digits. Added a function that handles the conversion of the stuff following TN. The function is so it's consistent across the parser, now it just converts the whole string of hex digits into a decimal integer using integer casting in python.

2. Fixed the parsing of things like "0:63", "0x64" to their respective expanded form.

3. Fixed the bug that made the program think that things were being placed in positions in positions beyond the arrays bounds.

4. Fixed the hardcoded default 1024 number of cores in the output file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/markplagge/nemo/39)
<!-- Reviewable:end -->
